### PR TITLE
Zeeshan dev

### DIFF
--- a/src/controllers/forum.controller.ts
+++ b/src/controllers/forum.controller.ts
@@ -14,7 +14,8 @@ import {
   updateCategorySchema,
   addBannedKeywordSchema,
   removeBannedKeywordSchema,
-  editThreadValidator 
+  editThreadValidator,
+  savePriorityValidator 
 } from "@src/shared/common/validators/forum.validator";
 import {
   defaultSchema,
@@ -620,6 +621,35 @@ public updateThreadStatus = async (req: Request, res: Response) => {
   }
 };
 
+
+
+
+
+  public saveCategoryPriority = async (req: Request, res: Response) => {
+    try {
+      const { error } = savePriorityValidator.validate(req.body);
+      if (error)
+        return res.status(400).json({ success: false, message: error.message });
+
+      const result = await this.__service.saveCategoryPriority(req.body);
+      res.status(200).json(result);
+    } catch (err: any) {
+      res.status(500).json({ success: false, message: err.message });
+    }
+  };
+
+  public saveSubCategoryPriority = async (req: Request, res: Response) => {
+    try {
+      const { error } = savePriorityValidator.validate(req.body);
+      if (error)
+        return res.status(400).json({ success: false, message: error.message });
+
+      const result = await this.__service.saveSubCategoryPriority(req.body);
+      res.status(200).json(result);
+    } catch (err: any) {
+      res.status(500).json({ success: false, message: err.message });
+    }
+  };
 
 
 

--- a/src/models/forumCategory.ts
+++ b/src/models/forumCategory.ts
@@ -18,6 +18,7 @@ export interface forumCategoryI {
   createdAt?: Date;
   updatedAt?: Date;
   deletedAt?: Date | null;
+  priority?: number;
 }
 
 @Table({
@@ -39,6 +40,13 @@ export class forumCategory extends Model<forumCategoryI> {
 
   @Column(DataType.STRING)
   public description: string;
+
+  @Column({
+    type: DataType.INTEGER,
+    defaultValue: 999,
+  })
+  public priority: number;
+
 
   @Column(DataType.STRING)
   public icon: string;

--- a/src/models/forumSubCategory.ts
+++ b/src/models/forumSubCategory.ts
@@ -19,6 +19,7 @@ export interface forumSubCategoryI {
   createdAt?: Date;
   updatedAt?: Date;
   deletedAt?: Date | null;
+  priority?: number;
 }
 
 @Table({
@@ -44,6 +45,13 @@ export class forumSubCategory extends Model<forumSubCategoryI> {
 
   @Column(DataType.STRING)
   public description: string;
+
+  @Column({
+    type: DataType.INTEGER,
+    defaultValue: 999,
+  })
+  public priority: number;
+
 
   @Column(DataType.DATE)
   public createdAt: Date;

--- a/src/models/report.ts
+++ b/src/models/report.ts
@@ -10,6 +10,7 @@ import {
 } from "sequelize-typescript";
 import { privateThreads } from "./privateThreads";
 import { threads } from "./threads";
+import { users } from "./users"; 
 
 export interface reportI {
   id?: number;
@@ -37,6 +38,10 @@ export class report extends Model<reportI> {
 
   @BelongsTo((): typeof threads => threads)
   public threads: typeof threads;
+
+  @BelongsTo((): typeof users => users, { foreignKey: "userId", as: "reporterUser" })
+  public reporterUser: typeof users;
+
 
   @PrimaryKey
   @AutoIncrement

--- a/src/routes/forum.routes.ts
+++ b/src/routes/forum.routes.ts
@@ -118,3 +118,18 @@ forumRouter.put("/messages/:messageId/unhide", (req, res) => forumController.unh
 
 // Single API for lock/unlock, hide/unhide, pin/unpin
 forumRouter.post("/thread/updateStatus", (req, res) => forumController.updateThreadStatus(req, res));
+
+
+
+
+
+// Save priorities
+forumRouter.put("/saveCategoryPriority", (req, res) =>
+  forumController.saveCategoryPriority(req, res)
+);
+
+forumRouter.put("/saveSubCategoryPriority", (req, res) =>
+  forumController.saveSubCategoryPriority(req, res)
+);
+
+

--- a/src/services/forum.service.ts
+++ b/src/services/forum.service.ts
@@ -981,37 +981,39 @@ export class ForumService {
   const reports = await report.findAll({
     include: [
       {
-        as: "threads",
         model: threads,
-        attributes: ["id", "title", "description", "createdAt"]
+        as: "threads",
       },
       {
-        as: "privateThreads",
         model: privateThreads,
-        attributes: ["id", "title", "createdAt"]
-      }
+        as: "privateThreads",
+      },
+      {
+        model: users,
+        as: "reporterUser",
+        attributes: ["id", "name", "email", "roleId"],
+      },
     ],
-    order: [["createdAt", "DESC"]]
+    order: [["createdAt", "DESC"]],
   });
 
   return reports.map((r: any) => ({
     id: r.id,
     problem: r.problem,
-    statusId: r.statusId,
-    createdAt: r.createdAt,
+    note: "Please view the detail page", // static note as per requirement
     reportedThread: r.reportedThreadId ? r.threads : null,
     reportedPrivateThread: r.reportedP_ThreadId ? r.privateThreads : null,
-    reporter: {
-      userId: r.userId,
-      roleId: r.roleId
-    },
-    reportedUser: {
-      userId: r.reportedUserId,
-      roleId: r.reportedRoleId
-    },
-    messageDetail: r.messageDetail
+    reporter: r.reporterUser ? {
+      id: r.reporterUser.id,
+      name: `${r.reporterUser.name}`,
+      email: r.reporterUser.email,
+      roleId: r.reporterUser.roleId
+    } : null,
+    createdAt: r.createdAt,
   }));
 };
+
+
 
 
 

--- a/src/shared/common/validators/forum.validator.ts
+++ b/src/shared/common/validators/forum.validator.ts
@@ -208,3 +208,15 @@ export const updateThreadStatusSchema = Joi.object({
     .required(),
   adminId: Joi.number().integer().optional(), // only for lock/unlock
 });
+
+
+export const savePriorityValidator = Joi.object({
+  priorities: Joi.array()
+    .items(
+      Joi.object({
+        id: Joi.number().required(),
+        priority: Joi.number().required(),
+      })
+    )
+    .required(),
+});


### PR DESCRIPTION
These fixes were made

10. In ‘reportedDiscussions’ we just need the complete reported thread object, the problem, please view the detail page, and the user who reported the chat, here we’re reporting the complete chat not a single message
11.  Create an api to set the priorities of the categories and subcategories, like what is on number 1, 2 etc, and send that priority in ‘getForumMainCategory’, ‘getForumSubCategory’, and ‘getForumCategoryList’